### PR TITLE
Add reset() method to PyRay

### DIFF
--- a/cpp/optics/Ray.cpp
+++ b/cpp/optics/Ray.cpp
@@ -21,3 +21,17 @@ std::ostream & operator<<(std::ostream & os, const Ray & ry)
 
 	return os;
 }
+
+void Ray::reset(const arr& new_v)
+{
+	v = new_v;
+	pos.resize(1);
+}
+
+void Ray::reset(const arr& new_v, const arr& new_start)
+{
+	v = new_v;
+
+	pos.resize(1);
+	pos[0] = new_start;
+}

--- a/cpp/optics/Ray.h
+++ b/cpp/optics/Ray.h
@@ -14,5 +14,10 @@ public:
 	Ray(arr init, arr v);
 
 	friend std::ostream& operator<<(std::ostream& os, const Ray& ry);
+
+	// Resets the Ray to only the first point in pos with specified new direction
+	// and resets the start position if specified
+	void reset(const arr& new_v);
+	void reset(const arr& new_v, const arr& new_start);
 };
 

--- a/cython_header.pxd
+++ b/cython_header.pxd
@@ -26,6 +26,9 @@ cdef extern from "Ray.h":
         vector[arr] pos
         arr v
 
+        void reset(arr)
+        void reset(arr, arr)
+
 cdef extern from "general.cpp":
     pass
 

--- a/testing/test_unittest.py
+++ b/testing/test_unittest.py
@@ -147,6 +147,41 @@ class Test_PyRay(unittest.TestCase, useful_checks):
 
         assert_allclose(r.plot(), expected_ans)
 
+    # Testing method reset()
+    def test_PyRay_reset_v(self):
+        """Test pyRay.reset(new_v) method"""
+        pos, v = np.zeros(2), np.array([1.0, 0.0])
+
+        r = tr.PyRay(pos, v)
+
+        # Trace the ray so its pos has more than one element
+        tr.PyTrace([], [r], n=3, fill_up=True)
+
+        new_v = np.array([0.0, -1.0])
+        r.reset(new_v)
+
+        assert_array_equal(r.pos.shape, (1, 2))
+        assert_array_equal(r.pos[0], pos)
+        assert_array_equal(r.v, new_v)
+
+    def test_PyRay_reset_v_pos(self):
+        """Test PyRay.reset(new_v, new_pos) method"""
+        pos, v = np.zeros(2), np.array([1.0, 0.0])
+
+        r = tr.PyRay(pos, v)
+
+        # Trace the ray so its pos has more than one element
+        tr.PyTrace([], [r], n=3, fill_up=True)
+
+        new_pos = np.array([2.0, 3.0])
+        new_v = np.array([0.0, -1.0])
+        r.reset(new_v, new_pos)
+
+        assert_array_equal(r.pos.shape, (1, 2))
+        assert_array_equal(r.pos[0], new_pos)
+        assert_array_equal(r.v, new_v)
+
+
 
 class Test_PyTrace(unittest.TestCase, useful_checks):
     """Tests for the tracing function PyTrace"""

--- a/tracing.pyx
+++ b/tracing.pyx
@@ -257,6 +257,44 @@ cdef class PyRay:
         
         return self.pos
 
+    def reset(self, double[:] new_v not None, double[:] new_p = None):
+        """
+        Resets the PyRay instance to the start position and is direction to
+        that of new_v. new_v is assumed to be normalised.
+
+        Parameters
+        ----------
+        new_v : numpy.ndarray
+            The new 2d direction of the ray. Should be a normalised numpy array
+            with shape (2,).
+        new_p : numpy.ndarray, optional
+            Initial 2d position of the ray. If not specified, the original 
+            initial position will be used. Should be a numpy array with shape
+            (2,).
+
+        Returns
+        -------
+        None. 
+        
+        """
+
+        if tuple(new_v.shape) != _arr_shape:
+            raise wrong_np_shape_except("new_v", new_v)
+
+        cdef arr n_v = make_arr_from_numpy(new_v)
+        cdef arr n_p
+
+        if new_p is None:
+            dereference(self.c_data).reset(n_v)
+        else:
+            if tuple(new_p.shape) != _arr_shape:
+                raise wrong_np_shape_except("new_p", new_p)
+
+            n_p = make_arr_from_numpy(new_p)
+
+            dereference(self.c_data).reset(n_v, n_p)
+
+
 # class _PyComponent
     
 cdef class _PyComponent:


### PR DESCRIPTION
- Add reset method to `PyRay` allowing the position data of the `PyRay` instance to be reset