### PR TITLE
Fix possible memory leak

### DIFF
--- a/cpp/optics/Complex_Component.cpp
+++ b/cpp/optics/Complex_Component.cpp
@@ -6,7 +6,10 @@ Complex_Component::Complex_Component(const Complex_Component &c)
 
 	for (auto& ptr : c.comps)
 	{
-		this->comps.emplace_back(ptr->clone());
+		// Ensure the raw pointer returned by ptr->clone() is wrapped up
+		// in a smart pointer so if push_back() throws, the memory isn't
+		// leaked
+		this->comps.push_back(std::shared_ptr<Component>(ptr->clone()));
 	}
 }
 


### PR DESCRIPTION
Ensure raw pointer returned by `clone()` is wrapped in smart pointer before being added to component list, to prevent leak.